### PR TITLE
Initial release 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,26 @@
 # BibTeX Plugin
 
 Many users use Joplin for research purposes, so it is natural for them to do citations all the time. Accordingly, adding a feature that supports citations and BibTeX will be of great benefit to Joplin. And here it is :)
-- For more info: https://discourse.joplinapp.org/c/gsoc-projects/bibtex-plugin  
+- For more info: https://discourse.joplinapp.org/c/gsoc-projects/bibtex-plugin
+
+![BibTeX Plugin Demo](https://i.ibb.co/TWrHVqF/Peek-2021-06-21-22-09.gif)
 
 ## Features
 - Read from a source of citations (a `.bib` file).
 - Allow the user to choose from a list of previously imported citations.
 - Insert references into the note content.
 
-## Screenshots
-- Config Screen:
-![enter image description here](https://aws1.discourse-cdn.com/standard14/uploads/cozic/original/2X/9/917deb9f15bdf64709f9a89a75f168a46bea1439.png)
+## Installation
+- Go to Tools > Options > Plugins
+- Search for `bibtex`
+- Click Install plugin
+- Restart Joplin to enable the plugin
+
+## How to use
+- Prepare a `BibTeX` file (if you are using Zotero, you can export your library as a `.bib` file)
+- Go to `Tools` > `Options` > `BibTeX Plugin` Section
+- Specify the path of your `.bib` file and click `Apply`
+- To Import a reference into your note content, simply click on the plugin icon in the toolbar and choose which reference to include, then click `OK`
 
 ## Building the plugin
 The plugin is built using Webpack, which creates the compiled code in `/dist`. A JPL archive will also be created at the root, which can use to distribute the plugin.
@@ -20,5 +30,4 @@ To build the plugin, simply run `npm run dist`.
 The project is setup to use TypeScript, although you can change the configuration to use plain JavaScript.
 
 ## Testing
-
 To test the plugin, simply run `npm test`. The testing library used is [Jest](https://jestjs.io/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-bibtex",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-bibtex",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
     "prepare": "npm run dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-bibtex",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",
     "prepare": "npm run dist",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "com.xUser5000.bibtex",
 	"app_min_version": "1.7",
-	"version": "1.0.0",
+	"version": "0.1.0",
 	"name": "BibTeX",
 	"description": "Use locally stored BibTeX files to insert citations into the current note.",
 	"author": "Abdallah Ahmed",


### PR DESCRIPTION
This is the first release ever of the BibTeX Plugin v0.1.0 🚀

## What has been done
- Register the "BibTeX Plugin" section in the config screen to allow the user to specify the source of references.
- Parse the `.bib` file specified by the user into JSON format.
- Added a toolbar button that triggers the main command of the plugin: `addBibTeXRefernce` Command.
- Added a dialog that pops up when the command is invoked to display a list of imported references.
- Allow the user to choose a reference from the list in order to be inserted into the note content.