### PR TITLE
Adjust the size of the citation popup according to content

### DIFF
--- a/src/ui/citation-popup/view.css
+++ b/src/ui/citation-popup/view.css
@@ -1,11 +1,13 @@
-* { overflow-wrap: break-word; }
-        
-body { width: 600px; }
+* {
+    overflow-wrap: break-word;
+    box-sizing: border-box;
+}
 
-ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+#joplin-plugin-content {
+    width: 900px;
+    height: auto;
+    max-height: 500px;
+    overflow-y: auto;
 }
 
 li {


### PR DESCRIPTION
- Set the width of the citation popup to be `900px`
- Show a scroll bar in case of content overflow 