### PR TITLE
fix #10: Prevent showing "Reference not found" when refusing to select any reference

### DIFF
--- a/src/add-bibtex-reference.command.ts
+++ b/src/add-bibtex-reference.command.ts
@@ -43,6 +43,9 @@ export async function registerAddBibTexReferenceCommand () {
                 // Show the citation popup and get the id of the selected reference
                 const referenceId: string = await showCitationPopup();
 
+                // If no reference was selected, exit the command
+                if (referenceId === "") return;
+
                 // Insert the selected reference into the note content
                 const selectedReference = DataStore.getReferenceById(referenceId);
                 await joplin.commands.execute(
@@ -56,7 +59,7 @@ export async function registerAddBibTexReferenceCommand () {
             } catch (e) {
                 console.log(e.message);
                 await joplin.views.dialogs.showMessageBox(
-                    `${ERROR_PARSING_FAILED} \n\n ${e.message}`
+                    `${ERROR_PARSING_FAILED}\n\n${e.message}`
                 );
             }
 

--- a/src/ui/citation-popup/index.ts
+++ b/src/ui/citation-popup/index.ts
@@ -34,8 +34,8 @@ export async function showCitationPopup (): Promise<string> {
 
     const result = await joplin.views.dialogs.open(popupHandle);
 
-    if (result.id === "no") return;
-    if (result.formData["main"]["reference_id"] === "") return;
+    if (result.id === "no") return "";
+    if (result.formData["main"]["reference_id"] === "") return "";
 
     // Insert the selected reference into the note content
     return decode(result.formData["main"]["reference_id"]);


### PR DESCRIPTION
This is a fix to issue #10

## What has been done
- Make `showCitationPopup()` return an empty string when there is no selected reference (previously it was returning undefined when encountering such situation).
- Check `if (referenceId === "") return;` in `add-bibtex-reference.command.ts`