### PR TITLE
fix(Citation Popup): Focus the search field initially

### DIFF
--- a/src/ui/citation-popup/view.js
+++ b/src/ui/citation-popup/view.js
@@ -74,6 +74,9 @@ function main () {
         });
         autoCompleteJS.searchEngine = "strict";
 
+        // Focus the input field
+        autoCompleteJS.input.focus();
+
         autoCompleteJS.input.addEventListener("selection", event => {
             const feedback = event.detail;
             const selection = feedback.selection.value;


### PR DESCRIPTION
When opening up, it will be useful to focus the search field automatically.