### PR TITLE
Render a full list of references at the bottom of the note viewer

### DIFF
--- a/plugin.config.json
+++ b/plugin.config.json
@@ -1,3 +1,5 @@
 {
-	"extraScripts": []
+	"extraScripts": [
+		"ui/bibliography-renderer/render-list-content-script.ts"
+	]
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,3 +8,4 @@ export const ADD_BIBTEX_REFERENCE_COMMAND = "addBibTeXReference";
 export const PLUGIN_TOOLBAR_BUTTON_ID = "bibtex_plugin_toolbar_button";
 export const CITATION_POPUP_ID = "citation_popup";
 export const ERROR_PARSING_FAILED = "Error while parsing BibTeX file: ";
+export const REFERENCE_LIST_CONTENT_SCRIPT_ID = "reference_lis_renderer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,15 @@ import joplin from 'api';
 import { initConfigScreen } from './ui/settings';
 import { registerToolbarButton } from './ui/toolbar-button';
 import { registerAddBibTexReferenceCommand } from './add-bibtex-reference.command';
+import { registerBibliographyRenderer } from './ui/bibliography-renderer';
 
 joplin.plugins.register({
 	onStart: async function() {
 		console.info('BibTeX plugin started!');
 
 		await initConfigScreen();
-
 		await registerAddBibTexReferenceCommand();
 		await registerToolbarButton();
+		await registerBibliographyRenderer();
 	}
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,10 @@
 import joplin from 'api';
-import { initConfigScreen } from './ui/settings';
-import { registerToolbarButton } from './ui/toolbar-button';
-import { registerAddBibTexReferenceCommand } from './add-bibtex-reference.command';
-import { registerBibliographyRenderer } from './ui/bibliography-renderer';
+import { init } from './init';
 
 joplin.plugins.register({
 	onStart: async function() {
 		console.info('BibTeX plugin started!');
 
-		await initConfigScreen();
-		await registerAddBibTexReferenceCommand();
-		await registerToolbarButton();
-		await registerBibliographyRenderer();
+		init();
 	}
 });

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,10 +8,8 @@ import { Reference } from "./model/reference.model";
 import { parse } from "./util/parser.util";
 import { DataStore } from "./data/data-store";
 import {
-    ADD_BIBTEX_REFERENCE_COMMAND,
-    PLUGIN_ICON,
-    SETTINGS_FILE_PATH_ID,
-    ERROR_PARSING_FAILED
+    ERROR_PARSING_FAILED,
+    SETTINGS_FILE_PATH_ID
 } from "./constants";
 const fs = joplin.require("fs-extra");
 
@@ -41,5 +39,10 @@ async function loadBibTeXData (): Promise<void> {
         const refs: Reference[] = parse(fileContent);
         DataStore.setReferences(refs);
 
-    } catch (e) { }
+    } catch (e) {
+        console.log(e);
+        await joplin.views.dialogs.showMessageBox(
+            `${ERROR_PARSING_FAILED}\n\n${e.message}`
+        );
+    }
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,45 @@
+import joplin from 'api';
+import { initConfigScreen } from './ui/settings';
+import { registerToolbarButton } from './ui/toolbar-button';
+import { registerAddBibTexReferenceCommand } from './add-bibtex-reference.command';
+import { registerBibliographyRenderer } from './ui/bibliography-renderer';
+
+import { Reference } from "./model/reference.model";
+import { parse } from "./util/parser.util";
+import { DataStore } from "./data/data-store";
+import {
+    ADD_BIBTEX_REFERENCE_COMMAND,
+    PLUGIN_ICON,
+    SETTINGS_FILE_PATH_ID,
+    ERROR_PARSING_FAILED
+} from "./constants";
+const fs = joplin.require("fs-extra");
+
+/**
+ * Initialize the main components of the plugin
+ */
+export async function init (): Promise<void> {
+
+    await initConfigScreen();
+    await registerAddBibTexReferenceCommand();
+    await registerToolbarButton();
+    await loadBibTeXData();
+    await registerBibliographyRenderer();
+
+}
+
+async function loadBibTeXData (): Promise<void> {
+    try {
+
+        // Get file Path and read the contents of the file
+        const filePath: string = await joplin.settings.value(SETTINGS_FILE_PATH_ID);
+        let fileContent: string;
+
+        fileContent = await fs.readFile(filePath, "utf8");
+
+        // Parse the raw data and store it
+        const refs: Reference[] = parse(fileContent);
+        DataStore.setReferences(refs);
+
+    } catch (e) { }
+}

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -1,0 +1,31 @@
+import joplin from "api";
+import { ContentScriptType } from "api/types";
+import { DataStore } from "../../data/data-store";
+import { fromRefToAPA } from "../../util/apa.util";
+import { REFERENCE_LIST_CONTENT_SCRIPT_ID } from "../../constants";
+
+/**
+ * Render the full list of references at the end of the note viewer
+ */
+export async function registerBibliographyRenderer (): Promise<void> {
+    
+    await joplin.contentScripts.register(
+        ContentScriptType.MarkdownItPlugin,
+        REFERENCE_LIST_CONTENT_SCRIPT_ID,
+        './ui/bibliography-renderer/render-list-content-script.js'
+    );
+
+    await joplin.contentScripts.onMessage(REFERENCE_LIST_CONTENT_SCRIPT_ID, (IDs: string[]) => {
+        let refs: string[] = [];
+        IDs.forEach(id => {
+            try {
+                refs.push(`
+                    <li>
+                        ${fromRefToAPA(DataStore.getReferenceById(id))}
+                    </li>
+                `);
+            } catch (e) {}
+        });
+        return refs;
+    });
+}

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -24,6 +24,7 @@ export async function registerBibliographyRenderer (): Promise<void> {
      */
     await joplin.contentScripts.onMessage(REFERENCE_LIST_CONTENT_SCRIPT_ID, (IDs: string[]) => {
         let refs: string[] = [];
+        IDs = [...new Set(IDs)];
         IDs.forEach(id => {
             try {
                 refs.push(`

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -9,12 +9,19 @@ import { REFERENCE_LIST_CONTENT_SCRIPT_ID } from "../../constants";
  */
 export async function registerBibliographyRenderer (): Promise<void> {
     
+    /* Register a new content script of type "markdown-it" */
     await joplin.contentScripts.register(
         ContentScriptType.MarkdownItPlugin,
         REFERENCE_LIST_CONTENT_SCRIPT_ID,
         './ui/bibliography-renderer/render-list-content-script.js'
     );
 
+    /**
+     * 1- Lookup reference objects based on their IDs (using DataStore)
+     * 2- Convert reference objects into APA format (in HTML)
+     * If some reference objects are not found, ignore them
+     * No need to html-escape the APA output, the library handles that
+     */
     await joplin.contentScripts.onMessage(REFERENCE_LIST_CONTENT_SCRIPT_ID, (IDs: string[]) => {
         let refs: string[] = [];
         IDs.forEach(id => {

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -24,7 +24,7 @@ export async function registerBibliographyRenderer (): Promise<void> {
      */
     await joplin.contentScripts.onMessage(REFERENCE_LIST_CONTENT_SCRIPT_ID, (IDs: string[]) => {
         let refs: string[] = [];
-        IDs = [...new Set(IDs)];
+        IDs = [...new Set(IDs)];        // Filter duplicate references
         IDs.forEach(id => {
             try {
                 refs.push(`

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -2,10 +2,10 @@ import { Reference } from "../../model/reference.model";
 
 declare const webviewApi: any;
 
-export default function(_context) { 
+export default function(context) { 
 	return {
 		plugin: function(markdownIt, _options) {
-			const contentScriptId = _context.contentScriptId;
+			const contentScriptId = context.contentScriptId;
 
 			/* Appends a new custom token for references list */
 			markdownIt.core.ruler.push("reference_list", async state => {

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -1,0 +1,53 @@
+import { Reference } from "../../model/reference.model";
+
+declare const webviewApi: any;
+
+export default function(_context) { 
+	return {
+		plugin: function(markdownIt, _options) {
+
+			const contentScriptId = _context.contentScriptId;
+
+			markdownIt.renderer.rules["reference_list"] = renderReferenceList;
+
+			markdownIt.core.ruler.push("reference_list", async state => {
+
+				/* Collect references from the note body */
+				const ids: Reference[] = [];
+				const refPattern: RegExp = /\[@.+\]\(.+\)/;
+				state.tokens.forEach(t => {
+					if (t["type"] !== "inline") return;
+					if (!refPattern.test(t["content"])) return;
+					ids.push(t["children"][1]["content"]);
+				});
+				
+				/* Append reference_list token */
+				let token = new state.Token("reference_list", "", 0);
+				token.attrSet("refs", ids);
+				state.tokens.push(token);
+			});
+			
+
+			function renderReferenceList (tokens, idx, options) {
+				let IDs: string[] = tokens[idx]["attrs"][0][1];
+				if (IDs.length === 0) return "";
+				
+				IDs = IDs.map(id => id.substring(1));
+
+				const script: string = `
+					webviewApi.postMessage("${contentScriptId}", ${JSON.stringify(IDs)}).then(refs => {
+						const referenceListView = document.getElementById("reference_list");
+						refs.forEach(ref => referenceListView.innerHTML += ref);
+					});
+					return false;
+				`;
+
+				return `
+					<h1>References</h1>
+					<ul id="reference_list"></ul>
+					<style onload='${script.replace(/\n/g, ' ')}'/>
+				`;
+			}
+		}
+	}
+}

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -5,11 +5,9 @@ declare const webviewApi: any;
 export default function(_context) { 
 	return {
 		plugin: function(markdownIt, _options) {
-
 			const contentScriptId = _context.contentScriptId;
 
-			markdownIt.renderer.rules["reference_list"] = renderReferenceList;
-
+			/* Appends a new custom token for references list */
 			markdownIt.core.ruler.push("reference_list", async state => {
 
 				/* Collect references from the note body */
@@ -27,6 +25,8 @@ export default function(_context) {
 				state.tokens.push(token);
 			});
 			
+			/* Define how to render the previously defined token */
+			markdownIt.renderer.rules["reference_list"] = renderReferenceList;
 
 			function renderReferenceList (tokens, idx, options) {
 				let IDs: string[] = tokens[idx]["attrs"][0][1];

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -57,8 +57,12 @@ export default function(context) {
 					webviewApi.postMessage("${contentScriptId}", ${JSON.stringify(IDs)}).then(refs => {
 						const referenceListView = document.getElementById("references_list");
 						const referenceTitleView = document.getElementById("references_title");
+
 						if (refs.length > 0) referenceTitleView.style.display = "block";
-						refs.forEach(ref => referenceListView.innerHTML += ref);
+
+						let ans = "";
+						refs.forEach(ref => ans += ref);
+						referenceListView.innerHTML = ans;
 					});
 					return false;
 				`;

--- a/src/util/apa.util.ts
+++ b/src/util/apa.util.ts
@@ -2,7 +2,7 @@ import * as Cite from "citation-js";
 import { Reference } from "../model/reference.model";
 
 /**
- * Converts a reference to APA format
+ * Converts a reference to APA format (in HTML)
  */
 export function fromRefToAPA (reference: Reference): string {
     return new Cite(reference).format("bibliography", {

--- a/src/util/apa.util.ts
+++ b/src/util/apa.util.ts
@@ -1,0 +1,13 @@
+import * as Cite from "citation-js";
+import { Reference } from "../model/reference.model";
+
+/**
+ * Converts a reference to APA format
+ */
+export function fromRefToAPA (reference: Reference): string {
+    return new Cite(reference).format("bibliography", {
+        format: 'html',
+        template: 'citation-apa',
+        lang: 'en-US'
+    });
+}

--- a/src/util/format-ref.util.ts
+++ b/src/util/format-ref.util.ts
@@ -6,7 +6,7 @@ import { escapeTitleText, escapeLinkUrl } from "./markdown.util";
  * Format a given reference as a valid markdown url
  */
 export function formatReference (ref: Reference): string {
-    const displayText: string = escapeTitleText(getDisplayText(ref));
+    const displayText: string = escapeTitleText(ref.id);
     const link: string = escapeLinkUrl(getLink(ref));
     return `[@${displayText}](${link})`;
 }

--- a/test/apa.test.ts
+++ b/test/apa.test.ts
@@ -1,0 +1,22 @@
+import { fromRefToAPA } from "../src/util/apa.util";
+import { Reference } from "../src/model/reference.model";
+import { promises as fs } from "fs";
+import { join } from "path";
+
+describe("APA Util", () => {
+
+    it("Convert json reference to APA format", async () => {
+        const data: Reference[] = JSON.parse(
+            await fs.readFile(join(__dirname, "assets", "test.json"), "utf-8")
+        );
+
+        const result: string = fromRefToAPA(data[0]).trim();
+        // console.log(`(${result})`);
+        const html: string = `<div class="csl-bib-body">
+  <div data-csl-entry-id="Steinbeck2003" class="csl-entry">Steinbeck, C., Han, Y., Kuhn, S., Horlacher, O., Luttmann, E., &#38; Willighagen, E. (2005). The Chemistry Development Kit (CDK): an open-source Java library for Chemo- and Bioinformatics. <i>Journal of Chemical Information and Computer Sciences</i>, <i>43</i>(2), 493–500. https://doi.org/10.1021/ci025584y</div>
+</div>`;
+
+        expect(result).toBe(html);
+    });
+
+});

--- a/test/format-ref.test.ts
+++ b/test/format-ref.test.ts
@@ -12,7 +12,7 @@ describe("Format Reference Util", () => {
 
         const result = formatReference(data[0]);
 
-        expect(result).toBe("[@Steinbeck2005](http://dx.doi.org/10.1021%2Fci025584y)");
+        expect(result).toBe("[@Steinbeck2003](http://dx.doi.org/10.1021%2Fci025584y)");
     });
 
     it("Format a reference having a URL without a DOI", async () => {
@@ -21,7 +21,7 @@ describe("Format Reference Util", () => {
         );
         const result = formatReference(data[1]);
 
-        expect(result).toBe("[@Bu2010](http://www.aclweb.org/anthology/D10-1109)");
+        expect(result).toBe("[@bu-EtAl:2010:EMNLP](http://www.aclweb.org/anthology/D10-1109)");
     });
 
     it("Format a reference with neither URL nor DOI", async () => {
@@ -31,7 +31,7 @@ describe("Format Reference Util", () => {
 
         const result = formatReference(data[2]);
         
-        expect(result).toBe("[@Smith2005](https://scholar.google.com/scholar?q=MedTag%3A%20A%20Collection%20of%20Biomedical%20Annotations%2C%20Smith)");
+        expect(result).toBe("[@smith-EtAl:2005:Biolink](https://scholar.google.com/scholar?q=MedTag%3A%20A%20Collection%20of%20Biomedical%20Annotations%2C%20Smith)");
     });
 
 });


### PR DESCRIPTION
## What has been done
- Register a markdown-it content script to render references at the bottom of the note viewer in APA format.
- Render both inline and block-level references.
- Parse and store references on startup
- Prevent rendering duplicate references
- Use the citekey as the display key of references. (Previously I used a combination of author + year of publication).