### PR TITLE
Customize the rendering of inline references

### DIFF
--- a/src/ui/bibliography-renderer/Message.ts
+++ b/src/ui/bibliography-renderer/Message.ts
@@ -1,2 +1,2 @@
 export const FORMAT_REFERENCES: string = "format_references";
-export const GET_REFERENCES_BY_ID: string = "get_reference_by_id";
+export const GET_REFERENCE_BY_ID: string = "get_reference_by_id";

--- a/src/ui/bibliography-renderer/Message.ts
+++ b/src/ui/bibliography-renderer/Message.ts
@@ -1,0 +1,2 @@
+export const FORMAT_REFERENCES: string = "format_references";
+export const GET_REFERENCES_BY_ID: string = "get_reference_by_id";

--- a/src/ui/bibliography-renderer/extract-references.ts
+++ b/src/ui/bibliography-renderer/extract-references.ts
@@ -5,31 +5,30 @@
  */
 export function extractReferences(tokens: any[]): string[] {
     const ids: string[] = [];
-    DFS(tokens, ids);
-    return ids;
-}
-
-function DFS(nodes: any[], ids): void {
-    /* Collect all words that matches the below regular expression */
     const referencePattern = /@(\w|:|\?|\-)+/g;
-    nodes.forEach((node) => {
-        if (
-            node["type"] === "text" &&
-            node.content &&
-            node.content.length > 1
-        ) {
-            /* A text token might contain several words separable by a space */
-            const content: string = node.content;
-            const matches = content.match(referencePattern);
-            if (matches && matches.length > 0) {
-                matches
-                    .map((word) => word.substring(1)) // Remove the @
-                    .forEach((word) => ids.push(word));
-            }
-        }
 
-        if (node["children"]) {
-            DFS(node["children"], ids);
-        }
-    });
+    /* Collect all words that matches the regular expression */
+    DFS(tokens);
+
+    function DFS(nodes: any[]): void {
+        nodes.forEach((node) => {
+            if (
+                node["type"] === "text" &&
+                node.content &&
+                node.content.length > 1
+            ) {
+                /* If matches found, add them to IDs without @ */
+                const matches = node.content.match(referencePattern);
+                if (matches && matches.length > 0) {
+                    matches.forEach((word) => ids.push(word.substring(1)));
+                }
+            }
+
+            if (node["children"]) {
+                DFS(node["children"]);
+            }
+        });
+    }
+
+    return ids;
 }

--- a/src/ui/bibliography-renderer/extract-references.ts
+++ b/src/ui/bibliography-renderer/extract-references.ts
@@ -1,41 +1,33 @@
-import { Reference } from "../../model/reference.model";
-
 /**
  * Given a list of markdown tokens and their children,
  * returns a list of reference IDs that exists in the markdown tree
  * Uses Depth-First-Search
  */
-export function extractReferences(tokens: any[]): Reference[] {
-    const ids: Reference[] = [];
+export function extractReferences(tokens: any[]): string[] {
+    const ids: string[] = [];
     DFS(tokens);
 
-    function DFS(children: any[]): void {
-        if (!children) return;
-
-        /* Search for three consecutive tokens: "link_open", "text", and "link_close" */
-        for (let i = 1; i < children.length - 1; i++) {
-            const curr = children[i],
-                prev = children[i - 1],
-                next = children[i + 1];
+    /* Collect all words that starts with @ */
+    function DFS(nodes: any[]): void {
+        nodes.forEach((node) => {
             if (
-                prev["type"] === "link_open" &&
-                curr["type"] === "text" &&
-                next["type"] === "link_close" &&
-                curr.content &&
-                curr.content.length > 1 &&
-                curr.content.startsWith("@")
+                node["type"] === "text" &&
+                node.content &&
+                node.content.length > 1
             ) {
-                const id = curr.content.substring(1);
-                ids.push(id);
-            } else {
-                if (curr["children"]) DFS(curr["children"]);
+                /* A text token might contain several words separable by a space */
+                const content: string = node.content;
+                content
+                    .split(" ")
+                    .filter((word) => word.startsWith("@"))
+                    .map((word) => word.substring(1)) // Remove the @
+                    .forEach((word) => ids.push(word));
             }
-        }
-        // first and last child that were not traversed previously
-        const last = children[children.length - 1],
-            first = children[0];
-        if (last["children"]) DFS(last["children"]);
-        if (first["children"]) DFS(first["children"]);
+
+            if (node["children"]) {
+                DFS(node["children"]);
+            }
+        });
     }
 
     return ids;

--- a/src/ui/bibliography-renderer/extract-references.ts
+++ b/src/ui/bibliography-renderer/extract-references.ts
@@ -1,0 +1,42 @@
+import { Reference } from "../../model/reference.model";
+
+/**
+ * Given a list of markdown tokens and their children,
+ * returns a list of reference IDs that exists in the markdown tree
+ * Uses Depth-First-Search
+ */
+export function extractReferences(tokens: any[]): Reference[] {
+    const ids: Reference[] = [];
+    DFS(tokens);
+
+    function DFS(children: any[]): void {
+        if (!children) return;
+
+        /* Search for three consecutive tokens: "link_open", "text", and "link_close" */
+        for (let i = 1; i < children.length - 1; i++) {
+            const curr = children[i],
+                prev = children[i - 1],
+                next = children[i + 1];
+            if (
+                prev["type"] === "link_open" &&
+                curr["type"] === "text" &&
+                next["type"] === "link_close" &&
+                curr.content &&
+                curr.content.length > 1 &&
+                curr.content.startsWith("@")
+            ) {
+                const id = curr.content.substring(1);
+                ids.push(id);
+            } else {
+                if (curr["children"]) DFS(curr["children"]);
+            }
+        }
+        // first and last child that were not traversed previously
+        const last = children[children.length - 1],
+            first = children[0];
+        if (last["children"]) DFS(last["children"]);
+        if (first["children"]) DFS(first["children"]);
+    }
+
+    return ids;
+}

--- a/src/ui/bibliography-renderer/extract-references.ts
+++ b/src/ui/bibliography-renderer/extract-references.ts
@@ -1,34 +1,35 @@
 /**
  * Given a list of markdown tokens and their children,
  * returns a list of reference IDs that exists in the markdown tree
- * Uses Depth-First-Search
+ * Uses recursive Depth-First-Search
  */
 export function extractReferences(tokens: any[]): string[] {
     const ids: string[] = [];
-    DFS(tokens);
+    DFS(tokens, ids);
+    return ids;
+}
 
-    /* Collect all words that starts with @ */
-    function DFS(nodes: any[]): void {
-        nodes.forEach((node) => {
-            if (
-                node["type"] === "text" &&
-                node.content &&
-                node.content.length > 1
-            ) {
-                /* A text token might contain several words separable by a space */
-                const content: string = node.content;
-                content
-                    .split(" ")
-                    .filter((word) => word.startsWith("@"))
+function DFS(nodes: any[], ids): void {
+    /* Collect all words that matches the below regular expression */
+    const referencePattern = /@(\w|:|\?|\-)+/g;
+    nodes.forEach((node) => {
+        if (
+            node["type"] === "text" &&
+            node.content &&
+            node.content.length > 1
+        ) {
+            /* A text token might contain several words separable by a space */
+            const content: string = node.content;
+            const matches = content.match(referencePattern);
+            if (matches && matches.length > 0) {
+                matches
                     .map((word) => word.substring(1)) // Remove the @
                     .forEach((word) => ids.push(word));
             }
+        }
 
-            if (node["children"]) {
-                DFS(node["children"]);
-            }
-        });
-    }
-
-    return ids;
+        if (node["children"]) {
+            DFS(node["children"], ids);
+        }
+    });
 }

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -6,7 +6,7 @@ import {
     REFERENCE_LIST_CONTENT_SCRIPT_ID,
     SETTINGS_CSL_FILE_PATH_ID,
 } from "../../constants";
-import { FORMAT_REFERENCES, GET_REFERENCES_BY_ID } from "./Message";
+import { FORMAT_REFERENCES, GET_REFERENCE_BY_ID } from "./Message";
 
 /**
  * Render the full list of references at the end of the note viewer
@@ -50,6 +50,16 @@ export async function registerBibliographyRenderer(): Promise<void> {
                      * Does html-encoding by default
                      */
                     return processor.formatRefs(IDs);
+                    break;
+
+                case GET_REFERENCE_BY_ID:
+                    console.log(req);
+                    const id = req["id"];
+                    try {
+                        return DataStore.getReferenceById(id);
+                    } catch (e) {
+                        return null;
+                    }
                     break;
             }
         }

--- a/src/ui/bibliography-renderer/index.ts
+++ b/src/ui/bibliography-renderer/index.ts
@@ -1,10 +1,10 @@
 import joplin from "api";
 import { ContentScriptType } from "api/types";
+import { DataStore } from "../../data/data-store";
 import { CSLProcessor } from "../../util/csl-processor";
 import {
     REFERENCE_LIST_CONTENT_SCRIPT_ID,
     SETTINGS_CSL_FILE_PATH_ID,
-    MESSAGE_RESTART_APP,
 } from "../../constants";
 
 /**
@@ -26,11 +26,22 @@ export async function registerBibliographyRenderer(): Promise<void> {
         REFERENCE_LIST_CONTENT_SCRIPT_ID,
 
         (IDs: string[]) => {
-            IDs = [...new Set(IDs)]; // Filter duplicate references
+            /**
+             * Filter duplicate IDs
+             * Filter fake IDs (IDs that don't correspond to actual reference objects)
+             */
+            IDs = [...new Set(IDs)].filter((id) => {
+                try {
+                    DataStore.getReferenceById(id);
+                    return true;
+                } catch (e) {
+                    return false;
+                }
+            });
 
             /**
              * Apply the specified citation style to the references
-             * Note: Does html-encoding by default
+             * Does html-encoding by default
              */
             return processor.formatRefs(IDs);
         }

--- a/src/ui/bibliography-renderer/render-inline-references.ts
+++ b/src/ui/bibliography-renderer/render-inline-references.ts
@@ -1,0 +1,77 @@
+import { GET_REFERENCE_BY_ID } from "./Message";
+
+/**
+ * Given a list of markdown tokens and their children,
+ * formats all inline references according to the syntax given here:
+ * https://discourse.joplinapp.org/t/customize-the-rendering-of-inline-references-spec/19294?u=xuser5000
+ * Uses recursive Depth-First-Search
+ */
+export function renderInlineReferences(
+    tokens: any[],
+    contentScriptId: string,
+    Token
+) {
+    DFS(tokens, contentScriptId, Token);
+}
+
+let pattern: RegExp = /\[-@(\w|:|\?|\-)+\]/g;
+function DFS(nodes: any[], contentScriptId: string, Token: any): void {
+    for (let i = 0; i < nodes.length; i++) {
+        if (nodes[i].type === "text") {
+            // If it's the default format, keep it as it is
+            if (
+                i - 1 >= 0 &&
+                nodes[i - 1].type === "link_open" &&
+                i + 1 < nodes.length &&
+                nodes[i + 1].type === "link_close"
+            ) {
+                continue;
+            }
+
+            const matches: string[] = nodes[i].content.match(pattern);
+            if (matches && matches.length) {
+                const textToken = new Token("text", "", 0);
+                textToken.content = "(Loading)";
+                nodes[i] = textToken;
+                console.log(nodes[i]);
+            }
+
+            // Get all the matches of the pattern and replace them with the formatted reference
+            /* const content: string = nodes[i].content;
+            const matches = content.match(pattern);
+            if (matches && matches.length) {
+                for (let j = 0; j < matches.length; j++) {
+                    const match = matches[j];
+                    const refId = match.substring(3, match.length - 1);
+                    const script: string = `
+                    webviewApi.postMessage("${contentScriptId}", ${JSON.stringify(
+                        {
+                            type: GET_REFERENCE_BY_ID,
+                            refId,
+                        }
+                    )}).then(reference => {
+                                const yearView = document.getElementById("bibtex-year-${j}");
+                                if (reference && reference.year) {
+                                    yearView.textContent = "(" + reference.year + ")";
+                                }
+
+                            });
+                            return false;
+                        `;
+
+                    const html: string = `
+                            <strong id="bibtex-year-${j}">(Loading...)</strong>
+                            <style onload='${script.replace(/\n/g, " ")}'/>`;
+                    console.log("Html " + html);
+
+                    content.replace(match, html);
+                }
+            } */
+        }
+
+        // Recursively search child nodes
+        if (nodes[i].children && nodes[i].children.length) {
+            DFS(nodes[i].children, contentScriptId, Token);
+        }
+    }
+}

--- a/src/ui/bibliography-renderer/render-inline-references.ts
+++ b/src/ui/bibliography-renderer/render-inline-references.ts
@@ -30,10 +30,12 @@ function DFS(nodes: any[], contentScriptId: string, Token: any): void {
 
             const matches: string[] = nodes[i].content.match(pattern);
             if (matches && matches.length) {
-                const textToken = new Token("text", "", 0);
-                textToken.content = "(Loading)";
-                nodes[i] = textToken;
-                console.log(nodes[i]);
+                if (!nodes[i].children) nodes[i].children = [];
+                matches.forEach((match) => {
+                    const refToken = new Token("inline_reference", "", 0);
+                    refToken.content = match;
+                    nodes[i].children.push(refToken);
+                });
             }
 
             // Get all the matches of the pattern and replace them with the formatted reference

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -1,4 +1,5 @@
 import { Reference } from "../../model/reference.model";
+import { extractReferences } from "./extract-references";
 
 export default function (context) {
     return {
@@ -7,38 +8,8 @@ export default function (context) {
 
             /* Appends a new custom token for references list */
             markdownIt.core.ruler.push("reference_list", async (state) => {
-                /* Collect references from the note body using Depth-first-search */
-                const ids: Reference[] = [];
-                dfs(state.tokens);
-
-                function dfs(children: any[]): void {
-                    if (!children) return;
-
-                    /* Search for three consecutive tokens: "link_open", "text", and "link_close" */
-                    for (let i = 1; i < children.length - 1; i++) {
-                        const curr = children[i],
-                            prev = children[i - 1],
-                            next = children[i + 1];
-                        if (
-                            prev["type"] === "link_open" &&
-                            curr["type"] === "text" &&
-                            next["type"] === "link_close" &&
-                            curr.content &&
-                            curr.content.length > 1 &&
-                            curr.content.startsWith("@")
-                        ) {
-                            const id = curr.content.substring(1);
-                            ids.push(id);
-                        } else {
-                            if (curr["children"]) dfs(curr["children"]);
-                        }
-                    }
-                    // first and last child that were not traversed previously
-                    const last = children[children.length - 1],
-                        first = children[0];
-                    if (last["children"]) dfs(last["children"]);
-                    if (first["children"]) dfs(first["children"]);
-                }
+                /* Collect references from the note body */
+                const ids: Reference[] = extractReferences(state.tokens);
 
                 /* Append reference_list token */
                 let token = new state.Token("reference_list", "", 0);

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -1,4 +1,5 @@
 import { extractReferences } from "./extract-references";
+import { FORMAT_REFERENCES, GET_REFERENCES_BY_ID } from "./Message";
 
 export default function (context) {
     return {
@@ -16,17 +17,20 @@ export default function (context) {
                 state.tokens.push(token);
             });
 
-            /* Define how to render the previously defined token */
-            markdownIt.renderer.rules["reference_list"] = renderReferenceList;
-
-            function renderReferenceList(tokens, idx, options) {
+            /* Define how to render the reference_list token */
+            markdownIt.renderer.rules["reference_list"] = function (
+                tokens,
+                idx,
+                options
+            ) {
                 let IDs: string[] = tokens[idx]["attrs"][0][1];
                 if (IDs.length === 0) return "";
 
                 const script: string = `
-					webviewApi.postMessage("${contentScriptId}", ${JSON.stringify(
-                    IDs
-                )}).then(html => {
+					webviewApi.postMessage("${contentScriptId}", ${JSON.stringify({
+                    type: FORMAT_REFERENCES,
+                    IDs,
+                })}).then(html => {
 						const referenceListView = document.getElementById("references_list");
 						const referenceTitleView = document.getElementById("references_title");
 

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -7,9 +7,9 @@ export default function (context) {
             const contentScriptId = context.contentScriptId;
 
             /* Appends a new custom token for references list */
-            markdownIt.core.ruler.push("reference_list", async (state) => {
+            markdownIt.core.ruler.push("reference_list", (state) => {
                 /* Collect references from the note body */
-                const ids: Reference[] = extractReferences(state.tokens);
+                const ids: string[] = extractReferences(state.tokens);
 
                 /* Append reference_list token */
                 let token = new state.Token("reference_list", "", 0);

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -1,4 +1,3 @@
-import { Reference } from "../../model/reference.model";
 import { extractReferences } from "./extract-references";
 
 export default function (context) {

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -1,5 +1,6 @@
 import { extractReferences } from "./extract-references";
-import { FORMAT_REFERENCES, GET_REFERENCES_BY_ID } from "./Message";
+import { renderInlineReferences } from "./render-inline-references";
+import { FORMAT_REFERENCES, GET_REFERENCE_BY_ID } from "./Message";
 
 export default function (context) {
     return {
@@ -46,7 +47,16 @@ export default function (context) {
 					<div id="references_list"></div>
 					<style onload='${script.replace(/\n/g, " ")}'/>
 				`;
-            }
+            };
+
+            /* Define how to render inline references (with custom styles) */
+            markdownIt.core.ruler.push("inline_reference", (state: any) => {
+                renderInlineReferences(
+                    state.tokens,
+                    contentScriptId,
+                    state.Token
+                );
+            });
         },
     };
 }

--- a/src/ui/bibliography-renderer/render-list-content-script.ts
+++ b/src/ui/bibliography-renderer/render-list-content-script.ts
@@ -56,7 +56,22 @@ export default function (context) {
                     contentScriptId,
                     state.Token
                 );
+                console.log(state.tokens);
             });
+
+            /*
+            I want to intercept all inline reference tokens and replace them with the appropriate html
+            But for some reason, It does not work
+            I still don't understand exactly how to do this
+            and the documentation of markdown-it does not help either
+            */
+            markdownIt.renderer.rules["inline_reference"] = function (
+                tokens,
+                idx,
+                options
+            ) {
+                return "<strong>(Loading...)</strong>";
+            };
         },
     };
 }


### PR DESCRIPTION
This PR is not yet complete, but I'm making it to request some help in Implementing this feature.
I've managed to find a way to collect all cite keys in the note body and add them to the bibliography section in the footer. However, I can't figure out how to proceed from here.

I'm trying to look for any of the patterns described [here](https://discourse.joplinapp.org/t/customize-the-rendering-of-inline-references-spec/19294). After encountering a pattern, I create a new token of type "inline_reference", replacing the old "text" token, to be parsed by the renderer later. But I still don't know how the renderer is supposed to do this, I tried just returning a random HTML but didn't work. The documentation of markdown-it does not help either

I need help, please.